### PR TITLE
iPhone X Padding Update && Shortname Fix

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,8 +1,9 @@
 import React, { Component } from 'react'
-import { Alert, Animated, Platform, StatusBar, StyleSheet, SafeAreaView } from 'react-native'
-import { AppLoading, Asset, Font, Notifications } from 'expo'
+import { Alert, Platform, StatusBar, View } from 'react-native'
+import { AppLoading, Font, Notifications } from 'expo'
+import { NativeRouter, Route } from 'react-router-native'
 
-import { NativeRouter, Route, Link } from 'react-router-native'
+import { getHeaderHeight } from './utils/deviceHelpers'
 
 import About from './app/screens/about/About'
 import Crest from './app/screens/crest/Crest'
@@ -10,7 +11,6 @@ import Home from './app/screens/home/Home'
 import Tables from './app/screens/tables/Tables'
 
 import FloatingButton from './app/components/Menu/FloatingButton'
-import HeaderBar from './app/components/HeaderBar/HeaderBar'
 import Menu from './app/components/Menu/Menu'
 
 export default class App extends Component {
@@ -18,6 +18,7 @@ export default class App extends Component {
     isReady: false,
     menuIsOpen: false,
     navigator: null,
+    canvasPaddingTop: 0
   }
 
   componentDidMount() {
@@ -26,6 +27,10 @@ export default class App extends Component {
         Alert.alert(data.title, data.body, { cancelable: false })
       }
     })
+
+    const canvasPaddingTop = Platform.OS === 'android' ? StatusBar.currentHeight : getHeaderHeight()
+
+    this.setState({ canvasPaddingTop })
   }
 
   async _cacheResourcesAsync() {
@@ -49,9 +54,7 @@ export default class App extends Component {
   }
 
   render() {
-    const { isReady, menuIsOpen } = this.state
-
-    const paddingTop = Platform.OS === 'android' ? StatusBar.currentHeight : 0
+    const { isReady, menuIsOpen, canvasPaddingTop } = this.state
 
     return !isReady ? (
       <AppLoading
@@ -61,26 +64,16 @@ export default class App extends Component {
       />
     ) : (
       <NativeRouter>
-        <SafeAreaView style={{ flex: 1, backgroundColor: '#08E5E3', paddingTop }}>
-          <StatusBar barStyle="light-content" />
+        <View style={{ flex: 1, backgroundColor: '#F0F0F0', paddingTop: canvasPaddingTop }}>
+          <StatusBar />
           <Route path="/" exact component={Home} />
           <Route path="/crest" component={Crest} />
           <Route path="/tables" component={Tables} />
           <Route path="/about" component={About} />
           <Menu isOpen={menuIsOpen} closeMenu={this.closeMenu} />
           <FloatingButton menuIsOpen={menuIsOpen} onPress={this.toggleMenu} />
-        </SafeAreaView>
+        </View>
       </NativeRouter>
     )
   }
 }
-
-const styles = StyleSheet.create({
-  container: {
-    bottom: 0,
-    left: 0,
-    position: 'absolute',
-    right: 0,
-    top: 20,
-  },
-})

--- a/app/components/Match/Match.js
+++ b/app/components/Match/Match.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { ActivityIndicator, ListView, Text, View, StyleSheet, Image, WebView } from 'react-native'
+import { View } from 'react-native'
 import InProgressMatch from './InProgressMatch'
 import ScheduledMatch from './ScheduledMatch'
 import CompletedMatch from './CompletedMatch'

--- a/app/components/Match/Matches.js
+++ b/app/components/Match/Matches.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react'
-import { FlatList, Image, StatusBar, StyleSheet, View } from 'react-native'
+import { FlatList, View } from 'react-native'
 import moment from 'moment'
+
+import { getSafeBottomPadding } from '../../../utils/deviceHelpers'
 
 import Match from './Match'
 import Loading from '../Loading/Loading'
@@ -8,6 +10,8 @@ import MatchesHeader from '../MatchesHeader/MatchesHeader'
 
 import Analytics from '../lib/analytics'
 import MatchService from '../lib/matchservice'
+
+const paddingBottom = getSafeBottomPadding(0)
 
 export default class Matches extends Component {
   state = {
@@ -82,10 +86,9 @@ export default class Matches extends Component {
 
   render() {
     const { matchDateRange, matches } = this.state
-    const { navigation } = this.props
 
     return (
-      <View style={{ flex: 1 }}>
+      <View style={{ flex: 1, paddingBottom }}>
         <MatchesHeader dateRange={matchDateRange} />
         <FlatList
           ref={component => (this.flatList = component)}

--- a/app/screens/tables/Group.js
+++ b/app/screens/tables/Group.js
@@ -75,7 +75,7 @@ const getLeft = team => <Text style={[styles.statText, styles.bold, { textAlign:
 const getItems = items =>
   items.map((item, index) => {
     const crest = item.club.crest ? { uri: item.club.crest } : tapInLogo
-    const shortName = item.club.shortName || ''
+    const shortName = item.club.shortName || item.club.clubName.substring(0,3).toUpperCase()
     const goalDiff = item.goalDifference === '+0' ? '0' : item.goalDifference
     let goalDiffColor = '#28323F'
     if (goalDiff.indexOf('+') === 0) {

--- a/package.json
+++ b/package.json
@@ -30,8 +30,9 @@
     "react-native": "https://github.com/expo/react-native/archive/sdk-25.0.0.tar.gz",
     "react-native-dimension": "^1.0.6",
     "react-native-htmlview": "^0.12.1",
-    "react-native-iphone-x-helper": "^1.0.2",
+    "react-native-iphone-x-helper": "^1.2.0",
     "react-native-simple-expand": "^0.1.3",
+    "react-native-status-bar-height": "^2.1.0",
     "react-native-table-component": "^1.1.3",
     "react-router-native": "^4.2.0",
     "sentry-expo": "~1.7.0"

--- a/utils/deviceHelpers.js
+++ b/utils/deviceHelpers.js
@@ -1,0 +1,29 @@
+import { Dimensions, Platform } from 'react-native';
+import { getStatusBarHeight } from 'react-native-status-bar-height';
+import { isIphoneX } from 'react-native-iphone-x-helper';
+
+export const LANDSCAPE = 'landscape';
+export const PORTRAIT = 'portrait';
+const statusBarHeight = getStatusBarHeight();
+
+export const isAndroid = () => Platform.OS === 'android'
+
+// This does not include the new bar area in the iPhone X, so I use this when I need a custom headerTitle component
+export const getHeaderHeight = () => {
+  const orientation = getOrientation();
+  if (Platform.OS === 'ios' && orientation === LANDSCAPE && !Platform.isPad) {
+    return 52;
+  }
+
+  return statusBarHeight;
+};
+
+export const getSafeBottomPadding = (initialPadding) => {
+  let newPadding = isIphoneX() ? (initialPadding + 24) : initialPadding;
+  return newPadding;
+};
+
+export const getOrientation = () => {
+  const { width, height } = Dimensions.get('window');
+  return width > height ? LANDSCAPE : PORTRAIT;
+};


### PR DESCRIPTION
This PR includes:
- an update to padding on the `Matches` screen of the mobile app. 
- update to tables. Uses club's first three characters of `name` when a `shortName` is not defined

iPhoneX was causing issues with top and bottom paddings. I've updated the background colors to be gray instead of the brand teal and added safe padding to the bottom of all matches depending on if the app is running on iPhone X or an older iPhone.

## iPhone X Padding Screenshots
### iPhone 8
![image](https://user-images.githubusercontent.com/1167326/46176979-37f15c80-c27f-11e8-8a4c-5b145d2ffa88.png)

### iPhone X
Note the padding at the bottom to keep match cards from being covered by the home screen line.
![image](https://user-images.githubusercontent.com/1167326/46177089-94ed1280-c27f-11e8-916d-5d0f9408400c.png)

## Club Shortname Fix Screenshots
Clubs like **Fulham** and **Wolves** don't have short names. This fix takes a substring of the first three characters of their full name.
![image](https://user-images.githubusercontent.com/1167326/46177209-0fb62d80-c280-11e8-9840-9516ce328e94.png)
